### PR TITLE
Load package rpivottable for RES network viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ This is the central tab for browsing and editing input data in a powerful pivot 
 <br />
 
 ### RES viewer<a name="res-viewer"></a>
-In the upper right corner of the input data tab there is a *switch view* button that allows to look at the RES network. The RES viewer provides `process centric`, `commodity centric` and `user constraint centric` views. All displayed items are clickable which allows convenient switching between different views. The corresponding table at the right and the pivot table at the bottom are updated automatically and show related data.
+In the upper right corner of the input data tab there is a *switch view* button that allows to look at the RES network. The RES viewer provides `process centric`, `commodity centric` and `user constraint centric` views. All displayed items are clickable which allows convenient switching between different views. The corresponding table at the right and the pivot table at the bottom are updated automatically and show related data. Note that the pivot table uses the package [rpivotTable](https://cran.rstudio.com/web/packages/rpivotTable/index.html) which is loaded when the application is started.
 
 ![res_network](static_times_miro/res_network.png)
 

--- a/conf_times_miro/times_miro.json
+++ b/conf_times_miro/times_miro.json
@@ -89,7 +89,8 @@
     },
     "cubeinput": {
       "outType": "mirorenderer_cubeinput",
-      "additionalData": ["dd_prc_desc", "dd_com_desc"]
+      "additionalData": ["dd_prc_desc", "dd_com_desc"],
+      "packages": ["rpivotTable"]
     }
   },
   "saveTraceFile": false,

--- a/renderer_times_miro/mirorenderer_cubeinput.R
+++ b/renderer_times_miro/mirorenderer_cubeinput.R
@@ -69,7 +69,7 @@ mirorenderer_cubeinputOutput <- function(id, height = NULL, options = NULL, path
                       ),
                       # Data View process
                       fluidRow(class = "row-custom side-padding",
-                               rpivotTableOutput(ns("data_prc"))
+                               rpivotTable::rpivotTableOutput(ns("data_prc"))
                       )),
              
              # Commodity Tab
@@ -127,7 +127,7 @@ mirorenderer_cubeinputOutput <- function(id, height = NULL, options = NULL, path
                       ),
                       # Data commodity view
                       fluidRow(class = "row-custom side-padding",
-                               rpivotTableOutput(ns("data_com"))
+                               rpivotTable::rpivotTableOutput(ns("data_com"))
                       )
              ),
              
@@ -182,7 +182,7 @@ mirorenderer_cubeinputOutput <- function(id, height = NULL, options = NULL, path
                       ),
                       # Data user constraint view
                       fluidRow(class = "row-custom side-padding",
-                               rpivotTableOutput(ns("data_uc"))
+                               rpivotTable::rpivotTableOutput(ns("data_uc"))
                       )
              )
            )
@@ -573,7 +573,7 @@ renderMirorenderer_cubeinput <- function(input, output, session, data, options =
   
   # Select data
   # Process-centric view data table
-  output$data_prc <- renderRpivotTable({
+  output$data_prc <- rpivotTable::renderRpivotTable({
     req(input$sel_prc)
     
     tableData <- noTopData 
@@ -594,7 +594,7 @@ renderMirorenderer_cubeinput <- function(input, output, session, data, options =
   })
   
   # Commodity-centric view data table
-  output$data_com <- renderRpivotTable({
+  output$data_com <- rpivotTable::renderRpivotTable({
     req(input$sel_com)
     
     tableData <- noTopData 
@@ -615,7 +615,7 @@ renderMirorenderer_cubeinput <- function(input, output, session, data, options =
   })
   
   # UC view data table
-  output$data_uc <- renderRpivotTable({
+  output$data_uc <- rpivotTable::renderRpivotTable({
     req(input$sel_uc)
     
     tableData <- ucData %>% dplyr::filter(uc_n == input$sel_uc)


### PR DESCRIPTION
Since the package [rpivotTable](https://cran.rstudio.com/web/packages/rpivotTable/index.html) will be dropped with the next MIRO release, it needs to be loaded as additional package in the RES viewer.